### PR TITLE
Remove READ_MEDIA_IMAGES permission

### DIFF
--- a/DocumentScanner/build.gradle.kts
+++ b/DocumentScanner/build.gradle.kts
@@ -69,7 +69,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.github.eci-rhc"
                 artifactId = "Document-Scanning-Android-SDK"
-                version = "1.3.0"
+                version = "1.3.1"
             }
         }
     }

--- a/DocumentScanner/src/main/AndroidManifest.xml
+++ b/DocumentScanner/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission
         android:name="android.permission.READ_PHONE_STATE"
         tools:node="remove" />
@@ -20,6 +19,18 @@
         android:largeHeap="true"
         android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
+
+        <!-- Prompt Google Play services to install the backported photo picker module -->
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
 
         <activity
             android:name=".ui.scan.InternalScanActivity"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.zynksoftware.documentscannersample"
         minSdk = 26
         targetSdk = 35
-        versionCode = 9
-        versionName = "1.3.0"
+        versionCode = 10
+        versionName = "1.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+<!--    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />-->
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
     <application

--- a/app/src/main/java/com/zynksoftware/documentscannersample/AppScanActivity.kt
+++ b/app/src/main/java/com/zynksoftware/documentscannersample/AppScanActivity.kt
@@ -105,7 +105,9 @@ class AppScanActivity : ScanActivity(), ImageAdapterListener {
 
     private fun getReadStoragePermission(): String {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            Manifest.permission.READ_MEDIA_IMAGES
+            // NOTE: Remove empty String and uncomment READ_MEDIA_IMAGES here and in AndroidManifest.xml only for testing purposes
+            ""
+//            Manifest.permission.READ_MEDIA_IMAGES
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 Manifest.permission.ACCESS_MEDIA_LOCATION


### PR DESCRIPTION
- From the demo app, just commented the use for a quick change
- From the library code, replace the permission with the Android Photo Picker, used when trying to add a photo from the Gallery to scan
- Bump to version 1.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  - Version bumped from 1.3.0 to 1.3.1

* **New Features**
  - Modernized image selection flow with improved Android API usage

* **Changes**
  - Streamlined permission handling for better compatibility
  - Enhanced Google Play services integration for improved functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->